### PR TITLE
squiggle to create plots in current dir

### DIFF
--- a/poretools/squiggle.py
+++ b/poretools/squiggle.py
@@ -55,7 +55,9 @@ def plot_squiggle(args, filename, start_times, mean_signals):
 			+ ggplot2.theme_bw()
 
 	if args.saveas is not None:
-		plot_file = filename + "." + args.saveas
+		plot_file = os.path.basename(filename) + "." + args.saveas
+		if os.path.isfile(plot_file):
+			raise Exception('Cannot create plot for %s: plot file %s already exists' % (filename, plot_file))
 		if args.saveas == "pdf":
 			grdevices.pdf(plot_file, width = 8.5, height = 11)
 		elif args.saveas == "png":


### PR DESCRIPTION
Hi,

Right now squiggle creates plots in the same directory as the FAST5 file. When working with tarballs, these plots end up being created in .poretools_tmp, which is cleaned out at the end, with all png/pdf's erased.

This change will cause plots to be created in the current directory named basename(fast5) + '.png' or '.pdf'. We fail if there are two FAST5s in the tarball or in the arguments with the same basename, so it won't overwrite plots.

--Misha
