### PR TITLE
Added support for extracting pre-basecalled events

### DIFF
--- a/docs/content/examples.rst
+++ b/docs/content/examples.rst
@@ -289,6 +289,16 @@ Extract the raw nanopore events from each FAST5 file.
     burn-in-run-2/ch100_file15_strand.fast5  template    49.6976788934   6595.9384   1.03634357984   0.0364  ATAGC   51.1117557194   1   0.181952967376  ATAGC   0.181952967376  0.296106771209  0.408638426765  0.0754069980523 0.217721405945  3
     burn-in-run-2/ch100_file15_strand.fast5  template    51.7633085659   6595.9748   1.04743182078   0.0456  TAGCA   52.6955397413   1   0.192582310652  TAGCA   0.192582310652  0.250481934498  0.311756355221  0.311208716953  0.12343821687   4
 
+Extract the pre basecalled events from each FAST5 file. 
+
+.. code-block:: bash
+    poretools events --pre-basecalled burn-in-run-2 | head -5
+    file    strand  mean    start   stdv    length  model_state     model_level     move    p_model_state   mp_model_state  p_mp_model_state        p_A     p_C     p_G     p_T     raw_index
+    burn-in-run-2/ch100_file15_strand.fast5     pre_basecalled  51.4652695313   5352344 0.655003995591      35
+    burn-in-run-2/ch100_file15_strand.fast5     pre_basecalled  60.1776123047   5352379 1.05143911309       18
+    burn-in-run-2/ch100_file15_strand.fast5     pre_basecalled  48.9152374359   5352397 0.864834628834      67
+    burn-in-run-2/ch100_file15_strand.fast5     pre_basecalled  55.4002178596   5352464 1.75915620083       17    
+
 ===================
 poretools ``times``
 ===================

--- a/poretools/Event.py
+++ b/poretools/Event.py
@@ -11,16 +11,46 @@ class Event(object):
 		self.start = row['start']
 		self.stdv = row['stdv']
 		self.length = row['length']
-		self.model_state = row['model_state']
-		self.model_level = row['model_level']
-		self.move = row['move']
-		self.p_model_state = row['p_model_state']
-		self.mp_state = row['mp_state']
-		self.p_mp_state = row['p_mp_state']
-		self.p_A = row['p_A']
-		self.p_C = row['p_C']
-		self.p_G = row['p_G']
-		self.p_T = row['p_T']
+		try:
+			self.model_state = row['model_state']
+		except IndexError:
+			self.model_state = ""
+		try:
+			self.model_level = row['model_level']
+		except IndexError:
+			self.model_level = ""
+		try:
+			self.move = row['move']
+		except IndexError:
+			self.move = ""
+		try:
+			self.p_model_state = row['p_model_state']
+		except IndexError:
+			self.p_model_state = ""
+		try:
+			self.mp_state = row['mp_state']
+		except IndexError:
+			self.mp_state = ""
+		try:
+			self.p_mp_state = row['p_mp_state']
+		except IndexError:
+			self.p_mp_state = ""
+		try:
+			self.p_A = row['p_A']
+		except IndexError:
+			self.p_A = ""
+		try:
+			self.p_C = row['p_C']
+		except IndexError:
+			self.p_C = ""
+		try:
+			self.p_G = row['p_G']
+		except IndexError:
+			self.p_G = ""
+		try:
+			self.p_T = row['p_T']
+		except IndexError:
+			self.p_T = ""
 
 	def __repr__(self):
 		return '\t'.join([str(s) for s in [self.mean, self.start, self.stdv,

--- a/poretools/Event.py
+++ b/poretools/Event.py
@@ -7,10 +7,22 @@ class Event(object):
 	"""
 	def __init__(self, row):
 		self.row = row
-		self.mean = row['mean']
-		self.start = row['start']
-		self.stdv = row['stdv']
-		self.length = row['length']
+		try:
+			self.mean = row['mean']
+		except IndexError:
+			self.mean = ""
+		try:
+			self.start = row['start']
+		except IndexError:
+			self.start = ""
+		try:
+			self.stdv = row['stdv']
+		except IndexError:
+			self.stdv = ""
+		try:
+			self.length = row['length']
+		except IndexError:
+			self.length = ""
 		try:
 			self.model_state = row['model_state']
 		except IndexError:

--- a/poretools/Fast5File.py
+++ b/poretools/Fast5File.py
@@ -17,7 +17,8 @@ from Event import Event
 
 fastq_paths = {'template' : '/Analyses/Basecall_2D_000/BaseCalled_template',
                'complement' : '/Analyses/Basecall_2D_000/BaseCalled_complement',
-               'twodirections' : '/Analyses/Basecall_2D_000/BaseCalled_2D'}
+               'twodirections' : '/Analyses/Basecall_2D_000/BaseCalled_2D',
+               'pre_basecalled' : '/Analyses/EventDetection_000/Reads/'}
 
 FAST5SET_FILELIST = 0
 FAST5SET_DIRECTORY = 1
@@ -176,6 +177,7 @@ class Fast5File(object):
 		self.have_fastas = False
 		self.have_templates = False
 		self.have_complements = False
+		self.have_pre_basecalled = False
 		self.have_metadata = False
 
 	def __del__(self):
@@ -335,6 +337,16 @@ class Fast5File(object):
 			self.have_complements = True
 		
 		return self.complement_events
+
+	def get_pre_basecalled_events(self):
+		"""
+		Return the table of pre-basecalled events
+		"""
+		if self.have_pre_basecalled is False:
+			self._extract_pre_basecalled_events()
+			self.have_pre_basecalled = True
+
+		return self.pre_basecalled_events		
 
 	####################################################################
 	# Flowcell Metadata methods
@@ -613,6 +625,19 @@ class Fast5File(object):
 			self.complement_events = [Event(x) for x in table['Events'][()]]
 		except Exception, e:
 			self.complement_events = []
+
+	def _extract_pre_basecalled_events(self):
+		"""
+		Pull out the pre-basecalled event information 
+		"""
+		# try:
+		table = self.hdf5file[fastq_paths['pre_basecalled']]
+		events = []
+		for read in table:
+			events.extend(table[read]["Events"][()])
+		self.pre_basecalled_events = [Event(x) for x in events]
+		# except Exception, e:
+			# self.pre_basecalled_events = []			
 
 	def _get_metadata(self):
 		try:

--- a/poretools/events.py
+++ b/poretools/events.py
@@ -8,13 +8,17 @@ def run(parser, args):
 			'p_model_state', 'mp_model_state', 'p_mp_model_state', \
 			'p_A', 'p_C', 'p_G', 'p_T', 'raw_index']
 	print "\t".join(keys)
-	
-	for fast5 in Fast5File.Fast5FileSet(args.files):
 
-		for event in fast5.get_template_events():
-			print '\t'.join([fast5.filename, 'template', str(event)]) 
-		for event in fast5.get_complement_events():
-			print '\t'.join([fast5.filename, 'complement', str(event)]) 
+	if args.pre_basecalled:
+		for fast5 in Fast5File.Fast5FileSet(args.files):
+			for event in fast5.get_pre_basecalled_events(): 
+				print '\t'.join([fast5.filename, 'pre_basecalled', str(event)])
+	else:
+		for fast5 in Fast5File.Fast5FileSet(args.files):
+			for event in fast5.get_template_events():
+				print '\t'.join([fast5.filename, 'template', str(event)]) 
+			for event in fast5.get_complement_events():
+				print '\t'.join([fast5.filename, 'complement', str(event)]) 
 
 		fast5.close()
 

--- a/poretools/poretools_main.py
+++ b/poretools/poretools_main.py
@@ -9,7 +9,7 @@ import logging
 logger = logging.getLogger('poretools')
 
 # poretools imports
-import version
+import poretools.version
 
 def run_subtool(parser, args):
     if args.command == 'combine':
@@ -64,7 +64,7 @@ def main():
     parser = argparse.ArgumentParser(prog='poretools', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("-v", "--version", help="Installed poretools version",
                         action="version",
-                        version="%(prog)s " + str(version.__version__))
+                        version="%(prog)s " + str(poretools.version.__version__))
     subparsers = parser.add_subparsers(title='[sub-commands]', dest='command', parser_class=ArgumentParserWithDefaults)
 
     #########################################

--- a/poretools/poretools_main.py
+++ b/poretools/poretools_main.py
@@ -9,7 +9,7 @@ import logging
 logger = logging.getLogger('poretools')
 
 # poretools imports
-import poretools.version
+import version
 
 def run_subtool(parser, args):
     if args.command == 'combine':
@@ -64,7 +64,7 @@ def main():
     parser = argparse.ArgumentParser(prog='poretools', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("-v", "--version", help="Installed poretools version",
                         action="version",
-                        version="%(prog)s " + str(poretools.version.__version__))
+                        version="%(prog)s " + str(version.__version__))
     subparsers = parser.add_subparsers(title='[sub-commands]', dest='command', parser_class=ArgumentParserWithDefaults)
 
     #########################################
@@ -118,7 +118,7 @@ def main():
                               dest='high_quality',
                               default=False,
                               action='store_true',
-                              help=('Only report reads with more complement events than template.'))
+                              help=('Only report reads with more complement events than template.'))   
     parser_fastq.set_defaults(func=run_subtool)
 
 
@@ -231,6 +231,11 @@ def main():
                                         help='Extract each nanopore event for each read.')
     parser_events.add_argument('files', metavar='FILES', nargs='+',
                              help='The input FAST5 files.')
+    parser_events.add_argument('--pre-basecalled',
+                              dest='pre_basecalled',
+                              default=False,
+                              action='store_true',
+                              help=('Report pre-basecalled events'))     
     parser_events.set_defaults(func=run_subtool)
 
     


### PR DESCRIPTION
Added support for extracting pre-basecalled events with a --pre-basecalled argument. 

Currently "events" gives you template and complement events. This PR adds an argument which allows you to extract the pre-basecalled events. 

e.g. looking at a file before metrichor basecalling:

	poretools events JR_FAA48708_08072015_ECL_CAV1411_1545_1_ch109_file7_strand.fast5  | head -n 5
	file    strand  mean    start   stdv    length  model_state     model_level     move    p_model_state   mp_model_state  p_mp_model_state        p_A     p_C     p_G     p_T     raw_index

with --pre_basecalled

	poretools events --pre-basecalled JR_FAA48708_08072015_ECL_CAV1411_1545_1_ch109_file7_strand.fast5  | head -n 5
	file    strand  mean    start   stdv    length  model_state     model_level     move    p_model_state   mp_model_state  p_mp_model_state        p_A     p_C     p_G     p_T     raw_index
	JR_FAA48708_08072015_ECL_CAV1411_1545_1_ch109_file7_strand.fast5     pre_basecalled  51.4652695313   5352344         35
	JR_FAA48708_08072015_ECL_CAV1411_1545_1_ch109_file7_strand.fast5     pre_basecalled  60.1776123047   5352379         18
	JR_FAA48708_08072015_ECL_CAV1411_1545_1_ch109_file7_strand.fast5     pre_basecalled  48.9152374359   5352397         67
	JR_FAA48708_08072015_ECL_CAV1411_1545_1_ch109_file7_strand.fast5     pre_basecalled  55.4002178596   5352464         17
