### PR TITLE
Added functionality to extract read metadata from the fast5 files

### DIFF
--- a/docs/content/examples.rst
+++ b/docs/content/examples.rst
@@ -316,4 +316,25 @@ Plot the throughput performance of each pore on the flowcell during a given sequ
 The result should look something like:
 
 .. image:: _images/occupancy.png
-    :width: 400pt    
+    :width: 400pt  
+
+
+===================
+poretools ``metadata``
+===================
+Extract the metadata from the fast5 file
+
+.. code-block:: bash
+
+    poretools metadata  013731_11rx_v2_3135_1_ch20_file19_strand.fast5
+
+    asic_id asic_temp   heatsink_temp
+    31037   28.11   37.88
+
+    poretools metadata --read  013731_11rx_v2_3135_1_ch20_file19_strand.fast5
+    filename    scaling_used    abasic_peak_height  hairpin_polyt_level median_before   start_time  read_id read_number hairpin_peak_height abasic_found    abasic_event_index  duration    start_mux   hairpin_found   hairpin_event_index
+    013731_11rx_v2_3135_1_ch20_file19_strand.fast5    1   124.31769966    0.413218809334  226.393825112   4648221 3b4e45bf-6d42-45bc-9314-1d8a630971c2    19  125.783167256   1   2   195322  4   1   1478
+
+
+
+

--- a/poretools/Fast5File.py
+++ b/poretools/Fast5File.py
@@ -630,14 +630,27 @@ class Fast5File(object):
 		"""
 		Pull out the pre-basecalled event information 
 		"""
-		# try:
-		table = self.hdf5file[fastq_paths['pre_basecalled']]
-		events = []
-		for read in table:
-			events.extend(table[read]["Events"][()])
-		self.pre_basecalled_events = [Event(x) for x in events]
-		# except Exception, e:
-			# self.pre_basecalled_events = []			
+		try:
+			table = self.hdf5file[fastq_paths['pre_basecalled']]
+			events = []
+			for read in table:
+				events.extend(table[read]["Events"][()])
+			self.pre_basecalled_events = [Event(x) for x in events]
+		except Exception, e:
+			self.pre_basecalled_events = []	
+
+	@property 
+	def read_metadata(self):
+		try:
+			table = self.hdf5file[fastq_paths['pre_basecalled']]
+			metadata = []
+			for read in table:
+				md = Fast5ReadMetaData(table[read])
+				metadata.extend(md)
+		except Exception, e:
+			metadata = []	
+		return [md.metadata_dict for md in metadata]
+
 
 	def _get_metadata(self):
 		try:
@@ -648,3 +661,21 @@ class Fast5File(object):
 			except Exception, e:
 				self.keyinfo = None
 				logger.warning("Cannot find keyinfo. Exiting.\n")
+
+
+
+class Fast5ReadMetaData(object):
+
+	def __init__(self, fast5_read_object):
+		self.metadata_dict = {}
+		self.read = fast5_read_object
+		self._extract_metadata_attributes()
+
+	def _extract_metadata_attributes(self):
+		for k in self.read.attrs.keys():
+			self.metadata_dict[k] = self.read.attrs[k]
+		print self.metadata_dict
+
+
+
+

--- a/poretools/Fast5File.py
+++ b/poretools/Fast5File.py
@@ -643,13 +643,13 @@ class Fast5File(object):
 	def read_metadata(self):
 		try:
 			table = self.hdf5file[fastq_paths['pre_basecalled']]
-			metadata = []
+			metadata_list = []
 			for read in table:
 				md = Fast5ReadMetaData(table[read])
-				metadata.extend(md)
+				metadata_list.append(md)
 		except Exception, e:
 			metadata = []	
-		return [md.metadata_dict for md in metadata]
+		return [md.metadata_dict for md in metadata_list]
 
 
 	def _get_metadata(self):
@@ -674,7 +674,6 @@ class Fast5ReadMetaData(object):
 	def _extract_metadata_attributes(self):
 		for k in self.read.attrs.keys():
 			self.metadata_dict[k] = self.read.attrs[k]
-		print self.metadata_dict
 
 
 

--- a/poretools/metadata.py
+++ b/poretools/metadata.py
@@ -2,14 +2,22 @@ import Fast5File
 
 def run(parser, args):
 
-	print "asic_id\tasic_temp\theatsink_temp"
+	if args.read:
+		# print "asic_id\tasic_temp\theatsink_temp"
+		for i, fast5 in enumerate(Fast5File.Fast5FileSet(args.files)):
+			for metadata_dict in fast5.read_metadata:
+				if i == 0:
+					header = metadata_dict.keys()
+					print "\t".join(["filename"] + header)
+				print "\t".join([fast5.filename] + [str( metadata_dict[k] ) for k in header])
+	else:
+		print "asic_id\tasic_temp\theatsink_temp"
+		for fast5 in Fast5File.Fast5FileSet(args.files):
 
-	for fast5 in Fast5File.Fast5FileSet(args.files):
+			asic_temp  = fast5.get_asic_temp()
+			asic_id = fast5.get_asic_id()
+			heatsink_temp = fast5.get_heatsink_temp()
 
-		asic_temp  = fast5.get_asic_temp()
-		asic_id = fast5.get_asic_id()
-		heatsink_temp = fast5.get_heatsink_temp()
+			print "%s\t%s\t%s" % (asic_id, asic_temp, heatsink_temp)
 
-		print "%s\t%s\t%s" % (asic_id, asic_temp, heatsink_temp)
-
-		fast5.close()
+			fast5.close()

--- a/poretools/metadata.py
+++ b/poretools/metadata.py
@@ -3,7 +3,6 @@ import Fast5File
 def run(parser, args):
 
 	if args.read:
-		# print "asic_id\tasic_temp\theatsink_temp"
 		for i, fast5 in enumerate(Fast5File.Fast5FileSet(args.files)):
 			for metadata_dict in fast5.read_metadata:
 				if i == 0:

--- a/poretools/poretools_main.py
+++ b/poretools/poretools_main.py
@@ -280,6 +280,11 @@ def main():
                                         help='Return run metadata such as ASIC ID and temperature from a set of FAST5 files')
     parser_metadata.add_argument('files', metavar='FILES', nargs='+',
                              help='The input FAST5 files.')
+    parser_metadata.add_argument('--read',
+                              dest='read',
+                              default=False,
+                              action='store_true',
+                              help=('Report read level metadata'))      
     parser_metadata.set_defaults(func=run_subtool)
 
     


### PR DESCRIPTION
There's useful pre-basecalled metadata in

/Analyses/EventDetection_000/Reads/

This PR allows you to extract a table of these values by using 

     poretools metadata --read  LomanLabz_013731_11rx_v2_3135_1_ch20_file19_strand.fast5

     filename	scaling_used	abasic_peak_height	hairpin_polyt_level	median_before	start_time	read_id	read_number	hairpin_peak_height	abasic_found	abasic_event_index	duration	start_mux	hairpin_found	hairpin_event_index
    LomanLabz_013731_11rx_v2_3135_1_ch20_file19_strand.fast5	1	124.31769966	0.413218809334	226.393825112	4648221	3b4e45bf-6d42-45bc-9314-1d8a630971c2	19	125.783167256	1	2	195322	4	1	1478