### PR TITLE
Dockerfile fixes for matplotlib and cython modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN echo 'deb http://cran.rstudio.com/bin/linux/ubuntu trusty/' >> /etc/apt/sour
 RUN apt-get update
 
 # Install dependencies
-RUN apt-get -y install git python-tables python-setuptools python-pip python-dev cython libhdf5-serial-dev r-base python-rpy2
+RUN apt-get -y install git python-tables python-setuptools python-pip python-dev cython libhdf5-serial-dev r-base python-rpy2 libfreetype6-dev pkg-config
 
 # Upgrade numexpr
 RUN pip install numexpr --upgrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN Rscript -e 'options("repos" = c(CRAN = "http://cran.rstudio.com/")); install
 
 # Install poretools
 RUN git clone https://github.com/arq5x/poretools /tmp/poretools
-RUN cd /tmp/poretools && python setup.py install
+WORKDIR /tmp/poretools
+RUN pip install -r requirements.txt
+RUN python setup.py install
 
 ############## INSTALLATION END ##############
 


### PR DESCRIPTION
The matplotlib fix is straight forward.  For the cython errors, it may be worth keeping #84 open to find a better fix; I would be happy to investigate any suggestions.  Although working around them by installing the requirements via pip at least helps the Docker image to build.