### PR TITLE
New type: best

### DIFF
--- a/docs/content/examples.rst
+++ b/docs/content/examples.rst
@@ -39,6 +39,13 @@ Extract sequences in FASTQ format from a set of FAST5 files.
     poretools fastq --type fwd,rev test_data/
 
 
+A type of "best" will extract the 2D read, if it exists. If not, it will extract either the template or complement read, whichever is available and has a better average Phred score.
+
+.. code-block:: bash
+
+    poretools fastq --type best test_data/
+
+
 Only extract sequence with more complement events than template. These are the so-called "high quality 2D reads" and are the most accurate sequences from a 
 given run.
 
@@ -61,6 +68,7 @@ Extract sequences in FASTA format from a set of FAST5 files.
     poretools fasta --type rev test_data/
     poretools fasta --type 2D test_data/
     poretools fasta --type fwd,rev test_data/
+    poretools fasta --type best test_data/
 
 =====================
 poretools ``combine``
@@ -172,6 +180,7 @@ Report the longest read among a set of FAST5 files.
     poretools winner --type rev test_data/
     poretools winner --type 2D test_data/
     poretools winner --type fwd,rev test_data/
+    poretools winner --type best test_data/
 
 ===================
 poretools ``stats``

--- a/poretools/formats.py
+++ b/poretools/formats.py
@@ -9,6 +9,16 @@ class Fastq(object):
 	def __repr__(self):
 		return '\n'.join([self.name, self.seq, self.sep, self.qual])
 
+	def est_error_rate(self):
+		"""
+		Returns an error rate estimate using the Phred quality scores.
+		"""
+		error_count = 0.0
+		for score in self.qual:
+			phred = ord(score) - 33
+			error_count += 10.0 ** (-phred / 10.0)
+		return error_count / len(self.qual)
+
 
 class Fasta(object):
 	def __init__(self, s):

--- a/poretools/formats.py
+++ b/poretools/formats.py
@@ -13,11 +13,15 @@ class Fastq(object):
 		"""
 		Returns an error rate estimate using the Phred quality scores.
 		"""
-		error_count = 0.0
-		for score in self.qual:
-			phred = ord(score) - 33
-			error_count += 10.0 ** (-phred / 10.0)
-		return error_count / len(self.qual)
+		try:
+			error_count = 0.0
+			for score in self.qual:
+				phred = ord(score) - 33
+				error_count += 10.0 ** (-phred / 10.0)
+			return error_count / len(self.qual)
+		except Exception, e:
+			return 0.0
+
 
 
 class Fasta(object):

--- a/poretools/poretools_main.py
+++ b/poretools/poretools_main.py
@@ -102,7 +102,7 @@ def main():
     parser_fastq.add_argument('--type',
                               dest='type',
                               metavar='STRING',
-                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev'],
+                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev', 'best'],
                               default='all',
                               help='Which type of FASTQ entries should be reported? Def.=all')
     parser_fastq.add_argument('--start',
@@ -153,7 +153,7 @@ def main():
     parser_fasta.add_argument('--type',
                               dest='type',
                               metavar='STRING',
-                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev'],
+                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev', 'best'],
                               default='all',
                               help='Which type of FASTQ entries should be reported? Def.=all')
     parser_fasta.add_argument('--start',
@@ -204,7 +204,7 @@ def main():
     parser_stats.add_argument('--type',
                               dest='type',
                               metavar='STRING',
-                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev'],
+                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev', 'best'],
                               default='all',
                               help='Which type of FASTQ entries should be reported? Def.=all')
     parser_stats.add_argument('--full-tsv',
@@ -290,7 +290,7 @@ def main():
     parser_tabular.add_argument('--type',
                               dest='type',
                               metavar='STRING',
-                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev'],
+                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev', 'best'],
                               default='all',
                               help='Which type of FASTA entries should be reported? Def.=all')
     parser_tabular.set_defaults(func=run_subtool)
@@ -365,9 +365,9 @@ def main():
     parser_qualpos.add_argument('--type',
                               dest='type',
                               metavar='STRING',
-                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev'],
+                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev', 'best'],
                               default='all',
-                              help='Which type of reads should be analyzed? Def.=all, choices=[all, fwd, rev, 2D, fwd,rev]')
+                              help='Which type of reads should be analyzed? Def.=all, choices=[all, fwd, rev, 2D, fwd,rev, best]')
     parser_qualpos.add_argument('--start',
                               dest='start_time',
                               default=None,
@@ -403,7 +403,7 @@ def main():
     parser_winner.add_argument('--type',
                               dest='type',
                               metavar='STRING',
-                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev'],
+                              choices=['all', 'fwd', 'rev', '2D', 'fwd,rev', 'best'],
                               default='all',
                               help='Which type of FASTA entries should be reported? Def.=all')
     parser_winner.set_defaults(func=run_subtool)


### PR DESCRIPTION
I wanted the ability to extract only one fastq file from each fast5. If a 2D read is available, then that's what I want. If only the template or only the complement read is available, then I'll take what's there. But if _both_ the template _and_ the complement are available (and not the 2D), then I want whichever of the two is better.

I saw the `# TODO "best". What is "best"?` comments in `Fast5File.py`, so I see I'm not the first to think of this! In order to choose the best, I used the mean error rate as determined by each read's Phred scores. Whichever read (template or complement) has a lower error rate is considered best. Ties go to template. But if someone can make a case as to why the Phred scores aren't a good way to choose the best read, I'd be keen to hear their reasoning.

I tried to update the code in all relevant places, including the docs. Hope I didn't miss anything!