### PR TITLE
potential fix for #78 

### DIFF
--- a/poretools/hist.py
+++ b/poretools/hist.py
@@ -1,6 +1,10 @@
 import sys
 import time
+
+import matplotlib
+matplotlib.use('Agg') # Must be called before any other matplotlib calls
 from matplotlib import pyplot as plt
+
 import seaborn as sns
 import Fast5File
 

--- a/poretools/yield_plot.py
+++ b/poretools/yield_plot.py
@@ -1,8 +1,11 @@
 import Fast5File
+import matplotlib
+matplotlib.use('Agg') # Must be called before any other matplotlib calls
+from matplotlib import pyplot as plt
+
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from matplotlib import pyplot as plt
 
 #logging
 import logging


### PR DESCRIPTION
potential fix for #78 

re-arranged order of library imports, added `matplotlib.use('Agg')` to avoid error `matplotlib “TclError: no display name” $DISPLAY`