### PR TITLE
Use the full GPG key ID.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ############# BEGIN INSTALLATION ##############
 
 # Prepare to install R
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN echo 'deb http://cran.rstudio.com/bin/linux/ubuntu trusty/' >> /etc/apt/sources.list
 RUN apt-get update
 


### PR DESCRIPTION
Hi Aaron,

Short GPG key IDs are getting too easy to fake with today's hardware, and the whole ecosystem is moving to longer IDs or even the full fingerprint, which I propose here.

See as well http://lwn.net/Articles/697417/ and https://bugs.debian.org/836553

Cheers,
## 

Charles
