### PR TITLE
Update Fast5File.py

### DIFF
--- a/poretools/Fast5File.py
+++ b/poretools/Fast5File.py
@@ -504,8 +504,9 @@ Please report this error (with the offending file) to:
 		self.hdf_internal_error("unknown HDF5 structure: can't find read block item")
 
 	def find_event_timing_block(self):
-		path = fastq_paths[self.version]['template'] % (self.group)
 		try:
+			# If for some reason there is not start_time, let's not have the entire program crash probably
+			path = fastq_paths[self.version]['template'] % (self.group)
 			node = self.hdf5file[path]
 			path = node.get('Events')
 #, getlink=True)


### PR DESCRIPTION
For some failed reads in issue #77 , this will allow the appropriate warnings to print to console

After this, running `poretools yield_plot --plot-type basepairs fail/` resulted in a series of Warnings but resulted in the correct plot

```
WARNING:poretools:No start time for fail/LabPC01_20161111_FNFAB38834_MN17678_sequencing_run_group4_161111_37640_ch97_read97_strand.fast5!
```
