### PR TITLE
add group switch to stats option

### DIFF
--- a/poretools/poretools_main.py
+++ b/poretools/poretools_main.py
@@ -212,6 +212,11 @@ def main():
                               default=False,
                               action='store_true',
                               help=('Verbose output in tab-separated format.'))
+    parser_stats.add_argument('--group',
+                              dest='group',
+                              default=0,
+                              type=int,
+                              help=('Base calling group serial number to extract, default 000'))
     parser_stats.set_defaults(func=run_subtool)
 
 

--- a/poretools/stats.py
+++ b/poretools/stats.py
@@ -43,7 +43,7 @@ def run(parser, args):
 				logger.warning("No valid sequences observed.\n")
 	else:
 		sizes = []
-		for fast5 in Fast5File.Fast5FileSet(args.files):
+		for fast5 in Fast5File.Fast5FileSet(args.files, group=args.group):
 			fas = fast5.get_fastas(args.type)
 			sizes.extend([len(fa.seq) for fa in fas if fa is not None])
 			fast5.close()


### PR DESCRIPTION
Allows user to specify group switch when calling "poretools stats"