### PR TITLE
Update yield_plot example to work with test_data

### DIFF
--- a/docs/content/examples.rst
+++ b/docs/content/examples.rst
@@ -97,7 +97,7 @@ Create a collector's curve reflecting the sequencing yield over time for a set o
 
 .. code-block:: bash
 
-    poretools yield_plot --plot-type reads test_data/
+    poretools yield_plot --plot-type reads test_data/2016*fast5
 
 The result should look something like:\
 
@@ -108,7 +108,7 @@ The second is the yield of base pairs over time:
 
 .. code-block:: bash
 
-    poretools yield_plot --plot-type basepairs test_data/
+    poretools yield_plot --plot-type basepairs test_data/2016*fast5
 
 The result should look something like:
     


### PR DESCRIPTION
A small update to the yield_plot example commands that groups test_data fast5 files from the same run,
Before:
<img width="785" alt="plot_1" src="https://cloud.githubusercontent.com/assets/8262853/22520478/6ac84da4-e882-11e6-9936-401ceb3cce68.png">
After:
<img width="785" alt="plot_2" src="https://cloud.githubusercontent.com/assets/8262853/22520485/73899ff6-e882-11e6-9102-f1d502606a1b.png">
